### PR TITLE
Add warning at install when mod is not available for game version

### DIFF
--- a/src/main/kotlin/net/axay/pacmc/commands/Install.kt
+++ b/src/main/kotlin/net/axay/pacmc/commands/Install.kt
@@ -124,7 +124,7 @@ object Install : CliktCommand(
         val modInfo = async { CurseProxy.getModInfo(modId.toInt()) }
 
         val file = files?.findBestFile(archive.minecraftVersion)?.first ?: kotlin.run {
-            notFoundMessage()
+            terminal.danger("Could not find anything for the given mod '$mod' in game version ${archive.minecraftVersion.versionString}")
             return@runBlocking
         }
 

--- a/src/main/kotlin/net/axay/pacmc/commands/Install.kt
+++ b/src/main/kotlin/net/axay/pacmc/commands/Install.kt
@@ -124,7 +124,7 @@ object Install : CliktCommand(
         val modInfo = async { CurseProxy.getModInfo(modId.toInt()) }
 
         val file = files?.findBestFile(archive.minecraftVersion)?.first ?: kotlin.run {
-            terminal.danger("Could not find anything for the given mod '$mod' in game version ${archive.minecraftVersion.versionString}")
+            terminal.danger("Could not find a release of '$mod' for the minecraft version '${archive.minecraftVersion.versionString}'")
             return@runBlocking
         }
 


### PR DESCRIPTION
When installing a mod with `pacmc install` the error message does not specify if the mod does not exist for the desired game version or does not exist at all. This small change tells the user that something under this name does exist, but not for his game version.