### PR TITLE
Support more project types

### DIFF
--- a/pacmc-app/src/commonMain/kotlin/net/axay/pacmc/app/features/Archive.kt
+++ b/pacmc-app/src/commonMain/kotlin/net/axay/pacmc/app/features/Archive.kt
@@ -316,7 +316,12 @@ class Archive(val name: String) {
                 }
 
                 val version = repoApiContext(CachePolicy.ONLY_FRESH) {
-                    it.getProjectVersions(modId, loaders)
+                    it.getProjectVersions(modId, buildList {
+                        addAll(loaders)
+                        loaders.forEach { loader ->
+                            addAll(loader.compatibleLoaders)
+                        }
+                    })
                 }?.findBest(minecraftVersion) ?: return
 
                 finalListMutex.withLock {

--- a/pacmc-common/src/commonMain/kotlin/net/axay/pacmc/common/data/ModLoader.kt
+++ b/pacmc-common/src/commonMain/kotlin/net/axay/pacmc/common/data/ModLoader.kt
@@ -3,10 +3,23 @@ package net.axay.pacmc.common.data
 enum class ModLoader(
     val displayName: String,
     val curseforgeId: Int?,
+    val compatibleLoaders: List<ModLoader> = emptyList(),
 ) {
     QUILT("Quilt", null),
     FABRIC("Fabric", 4),
     FORGE("Forge", 1);
+    FORGE("Forge", 1),
+    LITELOADER("LiteLoader", 3),
+    RIFT("Rift", null),
+    MODLOADER("Risugami's ModLoader", null),
+    BUKKIT("Bukkit", null),
+    SPIGOT("Spigot", null, listOf(BUKKIT)),
+    SPONGE("Sponge", null),
+    PAPER("Paper", null, listOf(BUKKIT, SPIGOT)),
+    PURPUR("Purpur", null, listOf(BUKKIT, SPIGOT, PAPER)),
+    BUNGEECORD("BungeeCord", null),
+    VELOCITY("Velocity", null),
+    WATERFALL("Waterfall", null, listOf(BUNGEECORD));
 
     val identifier = name.lowercase()
 }

--- a/pacmc-common/src/commonMain/kotlin/net/axay/pacmc/common/data/ModLoader.kt
+++ b/pacmc-common/src/commonMain/kotlin/net/axay/pacmc/common/data/ModLoader.kt
@@ -5,9 +5,8 @@ enum class ModLoader(
     val curseforgeId: Int?,
     val compatibleLoaders: List<ModLoader> = emptyList(),
 ) {
-    QUILT("Quilt", null),
     FABRIC("Fabric", 4),
-    FORGE("Forge", 1);
+    QUILT("Quilt", 5, listOf(FABRIC)),
     FORGE("Forge", 1),
     LITELOADER("LiteLoader", 3),
     RIFT("Rift", null),


### PR DESCRIPTION
## New Project Types

This PR adds support for:

- Rift *(modrinth only)*
- [Risugami's ModLoader](https://ftb.fandom.com/wiki/Risugami%27s_Modloader) However, this requires some more work to be usable that has to do with minecraft version handling as described in #47 *(modrinth only)*
- LiteLoader *(curseforge and modrinth)*
- Bukkit *(modrinth only atm)*
- Spigot *(modrinth only atm)*
- Paper *(modrinth only atm)*
- Purpur *(modrinth only atm)*
- BungeeCord *(modrinth only)*
- Waterfall *(modrinth only)*
- Velocity *(modrinth only)*
- Sponge *(modrinth only)*
- *CurseForge support for Quilt*

## Loader Compatibility

You can now create a Quilt archive and the archive will also be able to contain Fabric mods.
Same for Purpur Archives and Bukkit / Spigot / Paper Plugins and of course Waterfall archives with BungeeCord plugins.

This closes #68 